### PR TITLE
fix: importer buttons alignment

### DIFF
--- a/importer/components/ImporterAddon.vue
+++ b/importer/components/ImporterAddon.vue
@@ -212,7 +212,7 @@ export default {
                 />
             </div>
         </div>
-        <div class="importer-addon-wizard-navigation mt-3">
+        <div class="importer-addon-wizard-navigation mt-3 d-flex">
             <FlatButton
                 v-if="!isCurrentWorkflowUndefined"
                 type="button"
@@ -243,5 +243,7 @@ export default {
 </template>
 
 <style lang="scss">
-
+.importer-addon-wizard-navigation {
+    gap: .5rem;
+}
 </style>


### PR DESCRIPTION
Improve button alignment using flex and gap:

<img width="271" height="365" alt="image" src="https://github.com/user-attachments/assets/57943093-e144-43f5-ad91-469aba4a8456" />
